### PR TITLE
修复RichEdit对Riched20.lib的依赖导致VS2010及以上编译失败

### DIFF
--- a/src/DuiLib/UIRichEdit.cpp
+++ b/src/DuiLib/UIRichEdit.cpp
@@ -300,8 +300,19 @@ BOOL CTxtWinHost::Init(CRichEditUI *re, const CREATESTRUCT *pcs)
     fInplaceActive = TRUE;
 
     // Create Text Services component
-    if(FAILED(CreateTextServices(NULL, this, &pUnk)))
-        goto err;
+    //if(FAILED(CreateTextServices(NULL, this, &pUnk)))
+    //    goto err;
+	PCreateTextServices TextServicesProc = NULL;
+	HMODULE hmod = LoadLibrary(_T("msftedit.dll"));
+	if (hmod)
+	{
+		TextServicesProc = (PCreateTextServices)GetProcAddress(hmod,"CreateTextServices");
+	}
+
+	if (TextServicesProc)
+	{
+		HRESULT hr = TextServicesProc(NULL, this, &pUnk);
+	}
 
     hr = pUnk->QueryInterface(IID_ITextServices,(void **)&pserv);
 

--- a/src/LuaDui/stdafx.cpp
+++ b/src/LuaDui/stdafx.cpp
@@ -4,5 +4,5 @@
 
 #pragma comment( lib, "winmm.lib" )
 #pragma comment( lib, "comctl32.lib" )
-#pragma comment( lib, "Riched20.lib" )
+//#pragma comment( lib, "Riched20.lib" )
 #pragma comment( lib, "lua51.lib" )


### PR DESCRIPTION
修复RichEdit对Riched20.lib的依赖导致VS2010及以上编译失败
